### PR TITLE
Add HERE Android SDK examples on frontpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,6 +72,9 @@
 				client_secret : '918cbdf3a49ba292ff5e51e01e893ae0117c93ac'
 				},
 				repos = [
+					{id: 'here-android-sdk-examples',
+					type: 'Java',
+					description:'Java-based projects using the HERE SDK for Android'},
 					{id: 'here-ios-sdk-examples',
 					type: 'Objective-C',
 					description:'Objective-C-based projects using the HERE SDK for iOS'},


### PR DESCRIPTION
Add a new entry so that the Android SDK examples appear on https://heremaps.github.io/ please review.