### PR TITLE
Make things faster to render and preserve ordering, improve network efficiency

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -115,11 +115,11 @@ a:hover {
     position: relative;
     margin: 14px;
 }
-.desc {
+.repo-descr {
     color: #ffffff;
 }
 
-.teaser.dark > .desc {
+.teaser.dark > .repo-descr {
     margin: 5px;
     top: -22px;
     position: relative;
@@ -191,25 +191,23 @@ nav {
     margin-bottom: 30px;
 }
 
-.description {
+#repo-section {
     padding: 20px 5% 32px;
     display: flex;
     flex-wrap: wrap;
     justify-content: flex-start;
 }
 
-.header-desc {
+#repo-section p {
+  flex-basis: 300px;
+  flex-grow: 1;
+  padding: 10px;
+}
+
+.header-descr {
     padding: 20px 5% 32px;
     margin-left:20px;
 }
-
-.description p {
-    flex-basis: 300px;
-    flex-grow: 1;
-    padding: 10px;
-}
-
-
 
 /* Content */
 

--- a/index.html
+++ b/index.html
@@ -84,25 +84,35 @@
 
 		<script type="text/javascript">
 			var repos = [
-					'here-android-sdk-examples',
-					'here-ios-sdk-examples',
-					'bike-navigation',
-					'map-linkbuilder-app',
-					'postman-collections',
-					'maps-api-for-javascript-examples',
-					'jsfiddle-github',
-					'examples',
-					'dita-ot-plugins',
-					'developer-blog',
-					'data-lens-javascript-examples',
-					'here-aaa-java-sdk'
+					{id: 'here-android-sdk-examples'},
+					{id: 'here-ios-sdk-examples'},
+					{id: 'bike-navigation'},
+					{id: 'map-linkbuilder-app'},
+					{
+						id: 'postman-collections',
+						type: 'REST' // Override language value reported from API
+					},
+					{id: 'maps-api-for-javascript-examples'},
+					{id: 'jsfiddle-github'},
+					{id: 'examples'},
+					{
+						id: 'dita-ot-plugins',
+						type: 'XSLT' // Override language value reported from API
+					},
+					{id: 'developer-blog'},
+					{id: 'data-lens-javascript-examples'},
+					{id: 'here-aaa-java-sdk'}
 				],
+				repoTypeHash = {},
 				repoSectionTemplate = $('#repo-section-template').text(),
 				sections = [];
 
 			repos.forEach(function (repo, index) {
 				// Replace placeholder with relevant data
-				var sectionTemplateStr = repoSectionTemplate.replace(/\{repo-id\}/gi, repo);
+				var sectionTemplateStr = repoSectionTemplate.replace(/\{repo-id\}/gi, repo.id);
+				
+				// Populate a hash for faster repo type lookup via repo id
+				repoTypeHash[repo.id] = repo.type;
 				
 				// Create a document fragment out of the template text and push it on the sections array
 				sections.push($(sectionTemplateStr));
@@ -117,9 +127,15 @@
 				repo_data.forEach(function (data, index) {
 					/* The GitHub API will return more repos than the ones we expose here.
 						 Target only existing repo sections.*/
-					var $target = $('#repo-info-' + data.name);
+					var $target = $('#repo-info-' + data.name),
+							repo_language;
 					if ($target.length > 0) {
-						$target.find('[data-key="repo-type"]').text(data.language);
+						/* Check if we override the language ourselves by looking into the repoType hash.
+							 Fall-back to the value returned by the API; if that is null set to empty string
+						*/
+						repo_language = repoTypeHash[data.name] || data.language || '';
+						
+						$target.find('[data-key="repo-type"]').text(repo_language);
 						$target.find('[data-key="repo-descr"]').text(data.description);
 						$target.find('[data-key="repo-lastUpdate"]').text(moment(data.updated_at).format('ll'));
 						$target.find('[data-key="fork-count"]').text(data.forks_count);

--- a/index.html
+++ b/index.html
@@ -84,6 +84,8 @@
 
 		<script type="text/javascript">
 			var repos = [
+					{id: 'mobility-on-demand-use-cases-ios'},
+					{id: 'mobility-on-demand-use-cases-nodejs'},
 					{id: 'here-android-sdk-examples'},
 					{id: 'here-ios-sdk-examples'},
 					{id: 'bike-navigation'},

--- a/index.html
+++ b/index.html
@@ -67,14 +67,14 @@
 		<!-- Template note to be re-used when creating section panels -->
 		<script type="text/x-template" id="repo-section-template">
 			<section class="teaser dark" id="repo-info-{repo-id}">
-				<h5 data-key="repo-type">{repo-type}</h5>
+				<h5 data-key="repo-type">&nbsp;</h5>
 				<h2 data-key="repo-id"><a href="https://www.github.com/heremaps/{repo-id}" target="_blank" title="{repo-descr}">{repo-id}</a></h2>
-				<p class="repo-descr">{repo-descr}</p>
+				<p class="repo-descr" data-key="repo-descr">&nbsp;</p>
 				<div class="bottom">
-					<p class="alignleft">Update on <span data-role="repo-lastUpdate">-</span></p>
-					<p class="alignright" data-role="repo-stats">
-						<a href="https://www.github.com/heremaps/{repo-id}/network" target="_blank" class="link" title="Click here to see this project's forks"><img width="11px" height="14px" src="img/fork.png"><span data-role="fork-count"></span></a>&nbsp;
-						<a href="https://www.github.com/heremaps/{repo-id}/stargazers" target="_blank" class="link" title="Click here to see this project's stars"><img width="15px" height="14px" src="img/star.png"><span data-role="star-count"></span></a>
+					<p class="alignleft">Update on <span data-key="repo-lastUpdate">-</span></p>
+					<p class="alignright" data-key="repo-stats">
+						<a href="https://www.github.com/heremaps/{repo-id}/network" target="_blank" class="link" title="Click here to see this project's forks"><img width="11px" height="14px" src="img/fork.png"><span data-key="fork-count"></span></a>&nbsp;
+						<a href="https://www.github.com/heremaps/{repo-id}/stargazers" target="_blank" class="link" title="Click here to see this project's stars"><img width="15px" height="14px" src="img/star.png"><span data-key="star-count"></span></a>
 					</p>
 					<div class="clear"></div>
 				</div>
@@ -84,51 +84,26 @@
 
 		<script type="text/javascript">
 			var repos = [
-					{id: 'here-android-sdk-examples',
-					type: 'Java',
-					description:'Java-based projects using the HERE SDK for Android'},
-					{id: 'here-ios-sdk-examples',
-					type: 'Objective-C',
-					description:'Objective-C-based projects using the HERE SDK for iOS'},
-					{id: 'bike-navigation',
-					type: 'Eagle',
-					description:'A companion device that connects to the HERE app on Android, including an open-source toolkit to build a custom bike navigation device.'},
-					{id: 'map-linkbuilder-app',
-					type: 'JavaScript',
-					description:'A reference web application that showcases deeplinking to here.com.'},
-					{id: 'postman-collections',
-					type: 'REST',
-					description:'A series of Postman collections that demonstrate a variety of use cases for all HERE REST and Platform Extension APIs.'},
-					{id: 'maps-api-for-javascript-examples',
-					type: 'JavaScript',
-					description:'A series of JavaScript-based examples that use the HERE Maps API for JavaScript.'},
-					{id: 'jsfiddle-github',
-					type: 'JavaScript',
-					description:'A series of JavaScript-based examples that use the HERE Maps API for JavaScript for integration with JSFiddle.'},
-					{id: 'examples',
-					type: 'JavaScript',
-					description:'Self-contained examples for the legacy Maps API for JavaScript.'},
-					{id: 'dita-ot-plugins',
-					type: 'XSLT',
-					description:'A set of DITA Open Toolkit plugins developed internally at HERE.'},
-					{id: 'developer-blog',
-					type: 'Misc.',
-					description:'A set of examples and projects featured on the HERE developer blog.'},
-					{id: 'data-lens-javascript-examples',
-					type: 'JavaScript',
-					description:'A series of JavaScript-based code examples that use the HERE Data Lens JavaScript API.'},
-					{id: 'here-aaa-java-sdk',
-					type: 'Java',
-					description:'The complete source code for the HERE Authentication, Authorization, and Accounting Java SDK.'}
+					'here-android-sdk-examples',
+					'here-ios-sdk-examples',
+					'bike-navigation',
+					'map-linkbuilder-app',
+					'postman-collections',
+					'maps-api-for-javascript-examples',
+					'jsfiddle-github',
+					'examples',
+					'dita-ot-plugins',
+					'developer-blog',
+					'data-lens-javascript-examples',
+					'here-aaa-java-sdk'
 				],
 				repoSectionTemplate = $('#repo-section-template').text(),
 				sections = [];
 
 			repos.forEach(function (repo, index) {
-				// Replace placeholders with relevant data
-				var sectionTemplateStr = repoSectionTemplate.replace(/\{repo-id\}/gi, repo.id)
-																										.replace(/\{repo-type\}/gi, repo.type)
-																										.replace(/\{repo-descr\}/gi, repo.description);
+				// Replace placeholder with relevant data
+				var sectionTemplateStr = repoSectionTemplate.replace(/\{repo-id\}/gi, repo);
+				
 				// Create a document fragment out of the template text and push it on the sections array
 				sections.push($(sectionTemplateStr));
 			});
@@ -140,11 +115,15 @@
 			$.getJSON('https://api.github.com/orgs/heremaps/repos')
 			.done(function (repo_data) {
 				repo_data.forEach(function (data, index) {
+					/* The GitHub API will return more repos than the ones we expose here.
+						 Target only existing repo sections.*/
 					var $target = $('#repo-info-' + data.name);
 					if ($target.length > 0) {
-						$target.find('[data-role="repo-lastUpdate"]').text(moment(data.updated_at).format('ll'));
-						$target.find('[data-role="fork-count"]').text(data.forks_count);
-						$target.find('[data-role="star-count"]').text(data.stargazers_count);
+						$target.find('[data-key="repo-type"]').text(data.language);
+						$target.find('[data-key="repo-descr"]').text(data.description);
+						$target.find('[data-key="repo-lastUpdate"]').text(moment(data.updated_at).format('ll'));
+						$target.find('[data-key="fork-count"]').text(data.forks_count);
+						$target.find('[data-key="star-count"]').text(data.stargazers_count);
 					}
 				});
 			})

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 						</li>
 					</ul>
 				</nav>
-				<div class="header-desc">
+				<div class="header-descr">
 					<h1 class="title">HERE Maps on GitHub</h1>
 					<p class="intro">The leading location cloud.</p>
 					<div>
@@ -34,7 +34,7 @@
 		</header>
 
 		<div class="content-wrapper">
-			<div class="description">
+			<div id="repo-section">
 				<section class="teaser light">
 					<div class="spacer-top">&nbsp;</div>
 					<h1>More Info</h1>
@@ -55,8 +55,6 @@
 			</div>
 		</div>
 
-
-
 		<footer>
 				<span class="imprint">
 						<span class="copyright_string label_block">&copy; 2016	HERE</span> |
@@ -66,18 +64,26 @@
 				</span>
 		</footer>
 
-		<script>
-			var opt = {
-				client_id : 'heremaps-bot',
-				client_secret : '918cbdf3a49ba292ff5e51e01e893ae0117c93ac'
-				},
-				repos = [
-					{id: 'mobility-on-demand-use-cases-nodejs',
-					type: 'JavaScript',
-					description:'HERE mobility on-demand demos written as NodeJS applications'},
-					{id: 'mobility-on-demand-use-cases-ios',
-					type: 'Objective-C',
-					description:'HERE mobility on-demand demo written as an iOS application'},
+		<!-- Template note to be re-used when creating section panels -->
+		<script type="text/x-template" id="repo-section-template">
+			<section class="teaser dark" id="repo-info-{repo-id}">
+				<h5 data-key="repo-type">{repo-type}</h5>
+				<h2 data-key="repo-id"><a href="https://www.github.com/heremaps/{repo-id}" target="_blank" title="{repo-descr}">{repo-id}</a></h2>
+				<p class="repo-descr">{repo-descr}</p>
+				<div class="bottom">
+					<p class="alignleft">Update on <span data-role="repo-lastUpdate">-</span></p>
+					<p class="alignright" data-role="repo-stats">
+						<a href="https://www.github.com/heremaps/{repo-id}/network" target="_blank" class="link" title="Click here to see this project's forks"><img width="11px" height="14px" src="img/fork.png"><span data-role="fork-count"></span></a>&nbsp;
+						<a href="https://www.github.com/heremaps/{repo-id}/stargazers" target="_blank" class="link" title="Click here to see this project's stars"><img width="15px" height="14px" src="img/star.png"><span data-role="star-count"></span></a>
+					</p>
+					<div class="clear"></div>
+				</div>
+			</section>
+		</script>
+		<!-- Template node ends here -->
+
+		<script type="text/javascript">
+			var repos = [
 					{id: 'here-android-sdk-examples',
 					type: 'Java',
 					description:'Java-based projects using the HERE SDK for Android'},
@@ -114,37 +120,36 @@
 					{id: 'here-aaa-java-sdk',
 					type: 'Java',
 					description:'The complete source code for the HERE Authentication, Authorization, and Accounting Java SDK.'}
-				];
+				],
+				repoSectionTemplate = $('#repo-section-template').text(),
+				sections = [];
 
 			repos.forEach(function (repo, index) {
-				var section = document.createElement( 'section' ),
-				$section=  $(section);
-
-				$section.addClass( 'teaser dark' );
-				$section.html('<h5>' + repo.type + '</h5>' +
-						'<h2 data-role="name">' + repo.id + '</h2>' +
-						'<p class="desc">' + repo.description + '</p>' +
-						'<div class="bottom">' +
-						'	<p class="alignleft" data-role="lastUpdate"/><p class="alignright" data-role="statistics"/>' +
-						'	<div class="clear"></div>' +
-						'</div>');
-
-				$.getJSON('https://api.github.com/repos/heremaps/' + repo.id, opt, function(data) {
-					$section.find("[data-role='lastUpdate']").html('Updated on ' +
-							moment(data.updated_at).format('ll')
-							);
-					$section.find("[data-role='statistics']").html(
-						'<a href="' + data.forks_url + '" target="_blank" class="link" title="Click here to see this project\'s forks"><img width="11px" height="14px" src="img/fork.png"> ' + data.forks_count + '</a>&nbsp;' +
-						'<a href="' + data.stargazers_url + '" target="_blank" class="link" title="Click here to see this project\'s stars"><img width="15px" height="14px" src="img/star.png"> ' + data.stargazers_count + '</a>'
-							);
-					$section.find("[data-role='name']").html(
-							'<a href="' + data.html_url + '" target="_blank" title="' + data.description + '">' + data.name + '</a>'
-							);
-
-					$('.description').append( section );
-				})
-				.error(function() { });
-
+				// Replace placeholders with relevant data
+				var sectionTemplateStr = repoSectionTemplate.replace(/\{repo-id\}/gi, repo.id)
+																										.replace(/\{repo-type\}/gi, repo.type)
+																										.replace(/\{repo-descr\}/gi, repo.description);
+				// Create a document fragment out of the template text and push it on the sections array
+				sections.push($(sectionTemplateStr));
+			});
+			
+			// Append all sections to the DOM at once
+			$('#repo-section').append(sections);
+			
+			// Fire a single HTTP request to the GitHub API to fetch stats
+			$.getJSON('https://api.github.com/orgs/heremaps/repos')
+			.done(function (repo_data) {
+				repo_data.forEach(function (data, index) {
+					var $target = $('#repo-info-' + data.name);
+					if ($target.length > 0) {
+						$target.find('[data-role="repo-lastUpdate"]').text(moment(data.updated_at).format('ll'));
+						$target.find('[data-role="fork-count"]').text(data.forks_count);
+						$target.find('[data-role="star-count"]').text(data.stargazers_count);
+					}
+				});
+			})
+			.fail(function () {
+				console.log(arguments, "Error fetching repository information from the GitHub API!");
 			});
 		</script>
 	</body>


### PR DESCRIPTION
This mild refactor changes the page's rendering behaviour:

Instead of n HTTP requests (n=number of repos to expose) fired, each one blocking the rendering of its related section, we now render repository information sections at once with the most essential information at hand and then lazy-load star and fork counts.

Additionally since we don't wait for multiple AJAX requests to finish before rendering, rendering now reflects the order that repo information is stored.

Client secret and bot id have been removed as we do not do OAUTH via HTTP request; we just rely on an HTTP call to the unauthenticated API endpoint.

Should we reach a limit (e.g. when behind a firewall, sharing an ip) this does not degrade the experience much as we still have the most important pieces of information rendered.