### PR TITLE
Remove description field from link tag as it is not populated

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
 		<script type="text/x-template" id="repo-section-template">
 			<section class="teaser dark" id="repo-info-{repo-id}">
 				<h5 data-key="repo-type">&nbsp;</h5>
-				<h2 data-key="repo-id"><a href="https://www.github.com/heremaps/{repo-id}" target="_blank" title="{repo-descr}">{repo-id}</a></h2>
+				<h2 data-key="repo-id"><a href="https://www.github.com/heremaps/{repo-id}" target="_blank">{repo-id}</a></h2>
 				{travis-ci-build-status}
 				<p class="repo-descr" data-key="repo-descr">&nbsp;</p>
 				<div class="bottom">


### PR DESCRIPTION
A simple removal of a placeholder that is not populated due to the availability of description data during initial templating.

We could add an id / data-* attribute to target this link and update the value of "title" when we finish fetching data from the GitHub API. It is not worth the effort at this point.