### PR TITLE
index: Update the Travis URL from .org to .com

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,8 +86,8 @@
 		<!-- Template node to be re-used when creating Travis-CI badges -->
 		<script type="text/x-template" id="travis-badge-template">
 			<p class="travis-badge">
-				<a href="https://travis-ci.org/heremaps/{repo-id}" title="Travis-CI Build Status for heremaps/{repo-id}:{travis_ci_build_branch}">
-					<img src="https://travis-ci.org/heremaps/{repo-id}.svg?branch={travis_ci_build_branch}" alt="Build Status" data-canonical-src="https://travis-ci.org/heremaps/{repo-id}.svg?branch={travis_ci_build_branch}" style="max-width:100%;">
+				<a href="https://travis-ci.com/heremaps/{repo-id}" title="Travis-CI Build Status for heremaps/{repo-id}:{travis_ci_build_branch}">
+					<img src="https://travis-ci.com/heremaps/{repo-id}.svg?branch={travis_ci_build_branch}" alt="Build Status" data-canonical-src="https://travis-ci.com/heremaps/{repo-id}.svg?branch={travis_ci_build_branch}" style="max-width:100%;">
 				</a>
 			</p>
 		</script>


### PR DESCRIPTION
The majority of projects has been migrated from .org to .com for CI, so
rather use .com instead of .org as supporting both is not worth the
effort.

Signed-off-by: Sebastian Schuberth <sebastian.schuberth@here.com>