### PR TITLE
Remove Fira Sans in favor of FiraGO

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -83,7 +83,7 @@ a:hover {
 /* Buttons */
 
 .button-fill, .button-outline {
-    font-family: 'Fira Sans', sans-serif;
+    font-family: 'FiraGO', sans-serif;
     display: inline-block;
     padding: 12px 30px;
     font-size: 14px;


### PR DESCRIPTION
I had a single reference to `Fira Sans` in the button's CSS. Site still rendered on HERE machines fine since we most likely all have Fira Sans locally installed.

Change `Fira Sans` to `FiraGO`. Now button font renders properly.

Before:
<img width="601" alt="Screen Shot 2019-07-11 at 9 44 38 AM" src="https://user-images.githubusercontent.com/221746/61069297-cf640e00-a3c0-11e9-9b19-23727cc4ae51.png">

After:
<img width="628" alt="Screen Shot 2019-07-11 at 9 44 41 AM" src="https://user-images.githubusercontent.com/221746/61069303-d25efe80-a3c0-11e9-97cb-1fa26fdf9cdd.png">
